### PR TITLE
add support to customizable startup delay for processes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ clap = { version = "4.4.10", features = ["derive"] }
 colored = "2.1.0"
 ctrlc = "3.4.5"
 dotenvy = "0.15.7"
+duration-str = "0.13.0"
 futures-util = "0.3.30"
 http = "1.1.0"
 itertools = "0.13.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,8 +4,9 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
     fs::{self, File},
-    io::{Read, Write},
+    io::{Read, Write}, time::Duration,
 };
+use duration_str::deserialize_option_duration;
 
 #[cfg(not(windows))]
 static EXAMPLE_CONFIG: &str = include_str!("templates/cardamon.unix.toml");
@@ -215,6 +216,9 @@ pub struct Process {
     pub redirect: Option<Redirect>,
     #[serde(rename = "process")]
     pub process_type: ProcessType,
+    #[serde(deserialize_with = "deserialize_option_duration")]
+    #[serde(default)]
+    pub startup_grace: Option<Duration>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]


### PR DESCRIPTION
The 2000ms startup delay was too short in some cases for the containers to be created. I've added it as a config setting for Process, as this required startup grace period ususally depends on the process being started.

Having a proper readiness check would be better, but this did get me unblocked.